### PR TITLE
Support joined models and raise errors when needed

### DIFF
--- a/lib/wildsearcher.rb
+++ b/lib/wildsearcher.rb
@@ -1,7 +1,10 @@
 require "wildsearcher/version"
+require "wildsearcher/active_record_helper"
 require "active_record"
 
 module Wildsearcher
+  include ActiveRecordHelper
+
   def wildsearcher(params = {})
     field_array = params[:search_fields].to_s.split(",")
     term = params[:search_term].to_s.strip
@@ -10,35 +13,49 @@ module Wildsearcher
 
   def filter_records(search_fields: [], search_term: "")
     return default_scope if search_fields.empty? || search_term.blank?
+    check_missing_associations(search_fields)
     where(conditions(filter_fields(search_fields), search_term))
   end
 
   private def filter_fields(fields)
-    fields.keep_if do |f|
-      f.to_s.downcase.in? column_names
-    end
+    fields = add_table_name(fields)
+    fields.keep_if { |f| f.to_s.downcase.in?(joined_model_columns(fields)) }
   end
 
   private def conditions(fields, term)
     term = "%" + term.strip + "%" if db_like == "ILIKE"
-    [fields.map { |f| "cast(#{f} as text) #{db_like} ?" }.join(" OR ")] + ([term] * fields.count)
+    [fields.map { |f| "CAST(#{f} AS TEXT) #{db_like} ?" }.join(" OR ")] + ([term] * fields.count)
   end
 
-  private def default_scope
-    ::ActiveRecord::VERSION::MAJOR >= 4 ? all : scoped
-  end
-
-  private def db_like
-    case ::ActiveRecord::Base.connection.class.name.demodulize
-    when "PostgreSQLAdapter"
-      "ILIKE"
-    when "MysqlAdapter"
-      "LIKE"
-    else
-      raise NotImplementedError.new("Wildsearcher currently supports only Mysql and Postgresql.")
+  private def joined_model_columns(search_fields)
+    @joined_model_columns ||= begin
+      extract_model_names(search_fields).flat_map do |model_name|
+        extract_column_names(model_name).map do |column_name|
+          "#{model_name.pluralize}.#{column_name}"
+        end
+      end
     end
   end
 
+  private def extract_model_names(fields)
+    fields.map { |f| f.split('.').first if f.to_s.include?('.') }.compact.uniq
+  end
+
+  private def extract_column_names(model_name)
+    model_name.classify.safe_constantize.try(:column_names).to_a
+  end
+
+  private def add_table_name(fields)
+    fields.map { |f| f.include?('.') ? f : (table_name + '.' + f) }
+  end
+
+  private def check_missing_associations(search_fields)
+    extract_model_names(search_fields).map do |n|
+      unless table_name == n || reflect_on_association(n).present?
+        raise ActiveRecord::AssociationNotFoundError.new(new, n)
+      end
+    end
+  end
 end
 
 ::ActiveRecord::Base.extend(Wildsearcher)

--- a/lib/wildsearcher/active_record_helper.rb
+++ b/lib/wildsearcher/active_record_helper.rb
@@ -1,0 +1,16 @@
+module ActiveRecordHelper
+  private def default_scope
+    ::ActiveRecord::VERSION::MAJOR >= 4 ? all : scoped
+  end
+
+  private def db_like
+    case ::ActiveRecord::Base.connection.class.name.demodulize
+    when "PostgreSQLAdapter"
+      "ILIKE"
+    when "MysqlAdapter"
+      "LIKE"
+    else
+      raise NotImplementedError.new("Wildsearcher currently supports only Mysql and Postgresql.")
+    end
+  end
+end

--- a/lib/wildsearcher/version.rb
+++ b/lib/wildsearcher/version.rb
@@ -1,3 +1,3 @@
 module Wildsearcher
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end

--- a/spec/wildsearcher_spec.rb
+++ b/spec/wildsearcher_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe Wildsearcher do
   context "version" do
     subject { Wildsearcher::VERSION }
-    it { is_expected.to eq "1.0.1" }
+    it { is_expected.to eq "1.0.2" }
   end
 
 =begin


### PR DESCRIPTION
This enhancement introduces the support for searching on joined/included models. Search will be performed if the `car` model is associated with `origin` model and `origins` table has `capital_city` column. 

The relation needs to be predetermined so, in your controller, you will have to `include` or `join` the model like so `Cars.includes(:origin).references(:origin)` assuming that `Car` `has_one`/`belongs_to` `origin` in your model.

Nothing else needs to be changed, you'd still call `wildsearcher(params)` on your relation like so `Car.includes(:origin).references(:origin).wildsearcher(params)` in your index. This will support passing of field queries like `origin.capital_city`. Calling
`http://some.car_website.com?search_fields=year,make,vin,origin.capital_city&search_term=berl` should prepend `cars.` on all the search fields except `origin.capital_city` to ensure that there's no disambiguous  column name. If you misspelled the association name from say, `origin` to `orgin`, you can expect an `ActiveRecord::AssociationNotFoundError`. Its a 500 error, so ¯\\\_(ツ)_/¯, try spelling it better? Hopefully, you'll see a :beetle: in your result.