### PR TITLE
allow for active record 3.0 and up

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem "activerecord", "~> 4.2"
+gem "activerecord", ">= 3.0"
 
 group :development do
   gem 'guard-rspec', require: false

--- a/wildsearcher.gemspec
+++ b/wildsearcher.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 11.1"
   spec.add_development_dependency "rspec", "~> 3.4"
 
-  spec.add_dependency "activerecord", "~> 4.2"
+  spec.add_dependency "activerecord", ">= 3.0"
 
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }


### PR DESCRIPTION
Require only active record 3.0 and up so this can be used in rails 3. 